### PR TITLE
Created developer instructions

### DIFF
--- a/.github/workflows/dali_tests.yml
+++ b/.github/workflows/dali_tests.yml
@@ -34,8 +34,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dali,umap,h5] --extra-index-url https://developer.download.nvidia.com/compute/redist codecov
-          pip install mypy pytest-cov black
+          pip install .[dev,dali,umap,h5] --extra-index-url https://developer.download.nvidia.com/compute/redist codecov
 
       - name: Cache datasets
         uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[umap,h5] codecov mypy pytest-cov black
+          pip install -e .[dev,umap,h5]
 
       - name: Cache datasets
         uses: actions/cache@v2

--- a/.gitignore
+++ b/.gitignore
@@ -165,4 +165,10 @@ dmypy.json
 # Ignore all local history of files
 .history
 
+# Vim files
+*.sw?
+
+# Virtual env
+env/
+
 # End of https://www.gitignore.io/api/python,visualstudiocode

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The library is self-contained, but it is possible to use the models outside of s
 
 ---
 
+Please, check out our
+[documentation](https://solo-learn.readthedocs.io/en/latest) and
+[tutorials](#tutorials)
+
+---
+
 ## News
 * **[Aug 04 2022]**: :paintbrush: Added [MAE](https://arxiv.org/abs/2111.06377) and supports finetuning the backbone with `main_linear.py`, mixup, cutmix and [random augment](https://arxiv.org/abs/1909.13719).
 * **[Jul 13 2022]**: :sparkling_heart: Added support for [H5](https://docs.h5py.org/en/stable/index.html) data, improved scripts and data handling.
@@ -99,6 +105,7 @@ The library is self-contained, but it is possible to use the models outside of s
 * Custom model checkpointing with a simple file organization.
 
 ---
+
 ## Requirements
 * torch
 * torchvision
@@ -120,7 +127,10 @@ The library is self-contained, but it is possible to use the models outside of s
 
 ---
 
-## Installation
+## Installation (for users)
+
+*Note that if you are developing this repo, please see the [developer
+instructions](#Installation-for-users)
 
 First clone the repo.
 
@@ -155,7 +165,7 @@ There are extra experiments on K-NN evaluation in `bash_files/knn/` and feature 
 ---
 
 ## Tutorials
-Please, check out our [documentation](https://solo-learn.readthedocs.io/en/latest) and tutorials:
+
 * [Overview](https://solo-learn.readthedocs.io/en/latest/tutorials/overview.html)
 * [Offline linear eval](https://solo-learn.readthedocs.io/en/latest/tutorials/offline_linear_eval.html)
 * [Object detection](https://github.com/vturrisi/solo-learn/blob/main/downstream/object_detection/README.md)
@@ -281,6 +291,22 @@ We report the training efficiency of some methods using a ResNet18 with and with
 |              |:heavy_check_mark:| 42m 3s                     |  2m 6s  (64% faster) |      9244 MB          |
 
 **Note**: GPU memory increase doesn't scale with the model, rather it scales with the number of workers.
+
+---
+
+## Installation (for developers)
+
+```
+# Set up a virtual env (please make sure you aren't in conda or
+# that will cause pain)
+python3 -m venv env
+. env/bin/activate
+# Disable dali installation, since you are probably on a CPU when
+# doing laptop dev
+python3 -m pip  install .[dev,umap,h5]
+# Run test suite
+pytest --cov=solo tests/args tests/backbones tests/losses tests/methods tests/utils
+```
 
 ---
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ EXTRA_REQUIREMENTS = {
     "dali": ["nvidia-dali-cuda110"],
     "umap": ["matplotlib", "seaborn", "pandas", "umap-learn"],
     "h5": ["h5py"],
-    "dev": ["pytest", "pytest-cov", "codecov", "mypy", "pytest-cov"],
+    "dev": ["pytest", "pytest-cov", "codecov", "mypy"],
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,13 @@ EXTRA_REQUIREMENTS = {
     "dali": ["nvidia-dali-cuda110"],
     "umap": ["matplotlib", "seaborn", "pandas", "umap-learn"],
     "h5": ["h5py"],
+        "dev": [
+            "pytest",
+            "pytest-cov",
+            "codecov",
+            "mypy",
+            "pytest-cov"
+        ]
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ EXTRA_REQUIREMENTS = {
     "dali": ["nvidia-dali-cuda110"],
     "umap": ["matplotlib", "seaborn", "pandas", "umap-learn"],
     "h5": ["h5py"],
-    "dev": ["pytest", "pytest-cov", "codecov", "mypy"],
+    "dev": ["pytest", "pytest-cov", "codecov", "mypy", "black"],
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,20 +19,19 @@
 
 from setuptools import find_packages, setup
 
-KW = ["artificial intelligence", "deep learning", "unsupervised learning", "contrastive learning"]
+KW = [
+    "artificial intelligence",
+    "deep learning",
+    "unsupervised learning",
+    "contrastive learning",
+]
 
 
 EXTRA_REQUIREMENTS = {
     "dali": ["nvidia-dali-cuda110"],
     "umap": ["matplotlib", "seaborn", "pandas", "umap-learn"],
     "h5": ["h5py"],
-        "dev": [
-            "pytest",
-            "pytest-cov",
-            "codecov",
-            "mypy",
-            "pytest-cov"
-        ]
+    "dev": ["pytest", "pytest-cov", "codecov", "mypy", "pytest-cov"],
 }
 
 
@@ -44,7 +43,9 @@ def parse_requirements(path):
 
 setup(
     name="solo-learn",
-    packages=find_packages(exclude=["bash_files", "docs", "downstream", "tests", "zoo"]),
+    packages=find_packages(
+        exclude=["bash_files", "docs", "downstream", "tests", "zoo"]
+    ),
     version="1.0.3",
     license="MIT",
     author="solo-learn development team",


### PR DESCRIPTION
A few changes:

* 'dev' is an extra optional requirement, installing things like `pytest` and `pytest-cov`.
* Documentation is cleaned so that a) docs go straight at the top (it would be nice in the sidebar too but you have perms to do that; I didn't even know they exist); b) There is a separate section on how to get starting doing dev on `solo-learn`. (I wanted to try adding some patches but can't without this basic tooling to run easily.)
* One thing you might consider is having separate `dev` and `test` requirements. You can see [here](https://github.com/torchsynth/torchsynth/blob/main/setup.py) that a lot more dependencies are required for dev than test. But many people (like github CI) just want test deps.