### PR TITLE
Add precommit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,4 +165,7 @@ dmypy.json
 # Ignore all local history of files
 .history
 
+# vim
+*.sw?
+
 # End of https://www.gitignore.io/api/python,visualstudiocode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+-   repo: https://github.com/kynan/nbstripout
+    rev: 0.6.0
+    hooks:
+    -   id: nbstripout
+-   repo: https://github.com/mwouts/jupytext
+    rev: v1.14.1
+    hooks:
+    -   id: jupytext
+        args: [--sync, --pipe, black]
+        additional_dependencies:
+            - black==22.6.0 # Matches hook
+-   repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+    -   id: black
+        language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,4 +14,5 @@ repos:
     rev: 22.6.0
     hooks:
     -   id: black
+        args: [--line-length, 100]
         language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,5 +14,5 @@ repos:
     rev: 22.6.0
     hooks:
     -   id: black
-        args: [--line-length, 100]
+        args: [--line-length, "100"]
         language_version: python3

--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ If no Dali/UMAP/H5 support is needed, the repository can be installed as:
 pip3 install .
 ```
 
+For local development:
+```
+pip3 install -e .[umap,h5]
+# Make sure you have pre-commit hooks installed
+pre-commit install
+```
+
 **NOTE:** if you are having trouble with dali, install it following their [guide](https://github.com/NVIDIA/DALI).
 
 **NOTE 2:** consider installing [Pillow-SIMD](https://github.com/uploadcare/pillow-simd) for better loading times when not using Dali.

--- a/solo/methods/base.py
+++ b/solo/methods/base.py
@@ -267,8 +267,6 @@ class BaseMethod(pl.LightningModule):
                 "issues when resuming a checkpoint."
             )
 
-       
-
     @staticmethod
     def add_model_specific_args(parent_parser: ArgumentParser) -> ArgumentParser:
         """Adds shared basic arguments that are shared for all methods.


### PR DESCRIPTION
This is a nice way to keep new pushed code `black`'ed. (I see you also have a github action for this.)

I see use you ` --line-length 100` so I added that too.

To get this working, simply run:

```
pre-commit install
```

once.