### PR TITLE
add `dali_device` option to the Resize op

### DIFF
--- a/solo/data/dali_dataloader.py
+++ b/solo/data/dali_dataloader.py
@@ -385,7 +385,7 @@ def build_transform_pipeline_dali(dataset, cfg, dali_device):
         )
     else:
         augmentations.append(
-            ops.Resize(size=(cfg.crop_size, cfg.crop_size), interp_type=types.INTERP_CUBIC)
+            ops.Resize(device=dali_device, size=(cfg.crop_size, cfg.crop_size), interp_type=types.INTERP_CUBIC)
         )
 
     if cfg.color_jitter.prob:


### PR DESCRIPTION
This will support running the Resize op on the GPU.

Using the vanilla Resize op fails without the device key since it runs on the CPU by default. A small change in the code fixes this.

cc/ @anujinho