### PR TITLE
feat(ci): update pip caching in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,17 +19,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-
-      - name: Cache Python dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.python }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.python }}-pip-
+          cache: 'pip'
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
* updates `actions/setup-python` to `v4`.
* switch to the native pip caching of `actions/setup-python`.