### PR TITLE
Add FroSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Checkpoints are no longer available as of 2026. Re-running the scripts will yiel
 | BYOL         | ResNet18 |  1000  |  :x: |      92.58     |     99.79      |
 |DeepCluster V2| ResNet18 |  1000  |  :x: |      88.85     |     99.58      |
 | DINO         | ResNet18 |  1000  |  :x: |      89.52     |     99.71      |
+| FroSSL       | ResNet18 |  1000  |  :x: |      92.10     |     99.68      |
 | MoCo V2+     | ResNet18 |  1000  |  :x: |      92.94     |     99.79      |
 | MoCo V3      | ResNet18 |  1000  |  :x: |      93.10     |     99.80      |
 | NNCLR        | ResNet18 |  1000  |  :x: |      91.88     |     99.78      |
@@ -243,6 +244,7 @@ Checkpoints are no longer available as of 2026. Re-running the scripts will yiel
 | BYOL         | ResNet18 |  1000  |  :x: |      70.46     |     91.96      |
 |DeepCluster V2| ResNet18 |  1000  |  :x: |      63.61     |     88.09      |
 | DINO         | ResNet18 |  1000  |  :x: |      66.76     |     90.34      |
+| FroSSL       | ResNet18 |  1000  |  :x: |      69.52     |     91.04      |
 | MoCo V2+     | ResNet18 |  1000  |  :x: |      69.89     |     91.65      |
 | MoCo V3      | ResNet18 |  1000  |  :x: |      68.83     |     90.57      |
 | NNCLR        | ResNet18 |  1000  |  :x: |      69.62     |     91.52      |

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The library is self-contained, but it is possible to use the models outside of s
 * [BYOL](https://arxiv.org/abs/2006.07733)
 * [DeepCluster V2](https://arxiv.org/abs/2006.09882)
 * [DINO](https://arxiv.org/abs/2104.14294)
+* [FroSSL](https://arxiv.org/abs/2310.02903)
 * [MAE](https://arxiv.org/abs/2111.06377)
 * [MoCo V2+](https://arxiv.org/abs/2003.04297)
 * [MoCo V3](https://arxiv.org/abs/2104.02057)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,6 +68,7 @@ While the library is self contained, it is possible to use the models outside of
    solo/methods/byol
    solo/methods/deepclusterv2
    solo/methods/dino
+   solo/methods/frossl
    solo/methods/mae
    solo/methods/mocov2plus
    solo/methods/mocov3
@@ -93,6 +94,7 @@ While the library is self contained, it is possible to use the models outside of
    solo/losses/byol
    solo/losses/deepclusterv2
    solo/losses/dino
+   solo/losses/frossl
    solo/losses/mae
    solo/losses/mocov2plus
    solo/losses/mocov3

--- a/docs/source/solo/losses/frossl.rst
+++ b/docs/source/solo/losses/frossl.rst
@@ -1,0 +1,5 @@
+FroSSL
+------
+
+.. autofunction:: solo.losses.frossl.frossl_loss_func
+   :noindex:

--- a/docs/source/solo/methods/frossl.rst
+++ b/docs/source/solo/methods/frossl.rst
@@ -1,0 +1,26 @@
+FroSSL
+======
+
+
+.. automethod:: solo.methods.frossl.FroSSL.__init__
+   :noindex:
+
+add_and_assert_specific_cfg
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: solo.methods.frossl.FroSSL.add_and_assert_specific_cfg
+   :noindex:
+
+learnable_params
+~~~~~~~~~~~~~~~~
+.. autoattribute:: solo.methods.frossl.FroSSL.learnable_params
+   :noindex:
+
+forward
+~~~~~~~
+.. automethod:: solo.methods.frossl.FroSSL.forward
+   :noindex:
+
+training_step
+~~~~~~~~~~~~~
+.. automethod:: solo.methods.frossl.FroSSL.training_step
+   :noindex:

--- a/scripts/pretrain/cifar/frossl.yaml
+++ b/scripts/pretrain/cifar/frossl.yaml
@@ -1,0 +1,83 @@
+defaults:
+  - _self_
+  - wandb: private.yaml
+  - override hydra/hydra_logging: disabled
+  - override hydra/job_logging: disabled
+
+# disable hydra outputs
+hydra:
+  output_subdir: null
+  run:
+    dir: .
+
+name: "frossl-cifar10" # change here for cifar100
+method: "frossl"
+backbone:
+  name: "resnet18"
+method_kwargs:
+  proj_hidden_dim: 2048
+  proj_output_dim: 1024
+  invariance_weight: 1.0
+data:
+  dataset: cifar10 # change here for cifar100
+  train_path: "./datasets"
+  val_path: "datasets/imagenet100/val"
+  format: "image_folder"
+  num_workers: 4
+augmentations:
+  - rrc:
+      enabled: True
+      crop_min_scale: 0.2
+      crop_max_scale: 1.0
+    color_jitter:
+      enabled: True
+      brightness: 0.4
+      contrast: 0.4
+      saturation: 0.2
+      hue: 0.1
+      prob: 0.8
+    grayscale:
+      enabled: True
+      prob: 0.2
+    gaussian_blur:
+      enabled: False
+      prob: 0.0
+    solarization:
+      enabled: True
+      prob: 0.1
+    equalization:
+      enabled: False
+      prob: 0.0
+    horizontal_flip:
+      enabled: True
+      prob: 0.5
+    crop_size: 32
+    num_crops: 2
+optimizer:
+  name: "lars"
+  batch_size: 256
+  lr: 0.3
+  classifier_lr: 0.1
+  weight_decay: 1e-4
+  kwargs:
+    clip_lr: True
+    eta: 0.02
+    exclude_bias_n_norm: True
+scheduler:
+  name: "warmup_cosine"
+checkpoint:
+  enabled: True
+  dir: "trained_models"
+  frequency: 1
+auto_resume:
+  enabled: True
+
+# overwrite PL stuff
+max_epochs: 1000
+devices: [0]
+sync_batchnorm: True
+accelerator: "gpu"
+strategy: "ddp"
+# FroSSL's regularization term uses a log of a Frobenius norm, which is
+# numerically sensitive; full precision is recommended over mixed precision.
+precision: 32

--- a/scripts/pretrain/imagenet-100/frossl.yaml
+++ b/scripts/pretrain/imagenet-100/frossl.yaml
@@ -1,0 +1,55 @@
+defaults:
+  - _self_
+  - augmentations: symmetric.yaml
+  - wandb: private.yaml
+  - override hydra/hydra_logging: disabled
+  - override hydra/job_logging: disabled
+
+# disable hydra outputs
+hydra:
+  output_subdir: null
+  run:
+    dir: .
+
+name: "frossl-imagenet100"
+method: "frossl"
+backbone:
+  name: "resnet18"
+method_kwargs:
+  proj_hidden_dim: 2048
+  proj_output_dim: 1024
+  invariance_weight: 1.0
+data:
+  dataset: imagenet100
+  train_path: "datasets/imagenet100/train"
+  val_path: "datasets/imagenet100/val"
+  format: "dali"
+  num_workers: 4
+optimizer:
+  name: "lars"
+  batch_size: 256
+  lr: 0.3
+  classifier_lr: 0.1
+  weight_decay: 1e-4
+  kwargs:
+    clip_lr: True
+    eta: 0.02
+    exclude_bias_n_norm: True
+scheduler:
+  name: "warmup_cosine"
+checkpoint:
+  enabled: True
+  dir: "trained_models"
+  frequency: 1
+auto_resume:
+  enabled: True
+
+# overwrite PL stuff
+max_epochs: 400
+devices: [0, 1]
+sync_batchnorm: True
+accelerator: "gpu"
+strategy: "ddp"
+# FroSSL's regularization term uses a log of a Frobenius norm, which is
+# numerically sensitive; full precision is recommended over mixed precision.
+precision: 32

--- a/solo/losses/__init__.py
+++ b/solo/losses/__init__.py
@@ -21,6 +21,7 @@ from solo.losses.barlow import barlow_loss_func
 from solo.losses.byol import byol_loss_func
 from solo.losses.deepclusterv2 import deepclusterv2_loss_func
 from solo.losses.dino import DINOLoss
+from solo.losses.frossl import frossl_loss_func
 from solo.losses.mae import mae_loss_func
 from solo.losses.mocov2plus import mocov2plus_loss_func
 from solo.losses.mocov3 import mocov3_loss_func
@@ -38,6 +39,7 @@ __all__ = [
     "byol_loss_func",
     "deepclusterv2_loss_func",
     "DINOLoss",
+    "frossl_loss_func",
     "mae_loss_func",
     "mocov2plus_loss_func",
     "mocov3_loss_func",

--- a/solo/losses/frossl.py
+++ b/solo/losses/frossl.py
@@ -1,0 +1,79 @@
+# Copyright 2023 solo-learn development team.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies
+# or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+from typing import List, Tuple
+
+import torch
+import torch.nn.functional as F
+
+
+def frossl_loss_func(
+    z: List[torch.Tensor], invariance_weight: float = 1.0
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Computes the FroSSL loss given a list of projected views
+    (https://arxiv.org/abs/2310.02903).
+
+    The loss is the sum, over every view, of a Frobenius-norm regularization term
+    (which maximizes the entropy of the view's covariance/gram matrix) and an
+    invariance term (which pulls the views towards their mean). It supports any
+    number of views V >= 2.
+
+    Args:
+        z (List[torch.Tensor]): list of V NxD Tensors containing projected features,
+            one per view.
+        invariance_weight (float): weight of the invariance term. Defaults to 1.0.
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            total loss, invariance term and regularization term (summed over views).
+            The individual terms are returned so that the method can log them, keeping
+            this function side-effect free like the other loss functions in solo-learn.
+    """
+
+    N = z[0].size(0)
+    D = z[0].size(1)
+    V = len(z)
+
+    # normalize each view along the batch dimension
+    normalized_z = [F.normalize(zv, p=2, dim=0) for zv in z]
+    average_embedding = torch.mean(torch.stack(normalized_z), dim=0)
+
+    total_invariance = z[0].new_zeros(())
+    total_regularization = z[0].new_zeros(())
+    for view_embeddings in normalized_z:
+        # regularization term (eq. 6 in the paper): maximize the entropy of the
+        # (auto)covariance matrix, estimated through its squared Frobenius norm.
+        if N > D:
+            cov = view_embeddings.T @ view_embeddings
+        else:
+            cov = view_embeddings @ view_embeddings.T
+        # .item() avoids a float16 casting issue when dividing by the trace
+        cov = cov / torch.trace(cov).item()
+        fro_norm = torch.linalg.norm(cov, ord="fro")
+        # the 2 brings the frobenius square outside of the log
+        regularization = 2 * torch.log(fro_norm)
+        total_regularization = total_regularization + regularization
+
+        # invariance term (eq. 3 in the paper): pull each view towards the mean view
+        invariance = V * D * F.mse_loss(view_embeddings, average_embedding)
+        total_invariance = total_invariance + invariance
+
+    total_invariance = invariance_weight * total_invariance
+    loss = total_regularization + total_invariance
+    return loss, total_invariance, total_regularization

--- a/solo/methods/__init__.py
+++ b/solo/methods/__init__.py
@@ -22,6 +22,7 @@ from solo.methods.base import BaseMethod
 from solo.methods.byol import BYOL
 from solo.methods.deepclusterv2 import DeepClusterV2
 from solo.methods.dino import DINO
+from solo.methods.frossl import FroSSL
 from solo.methods.linear import LinearModel
 from solo.methods.mae import MAE
 from solo.methods.mocov2plus import MoCoV2Plus
@@ -49,6 +50,7 @@ METHODS = {
     "byol": BYOL,
     "deepclusterv2": DeepClusterV2,
     "dino": DINO,
+    "frossl": FroSSL,
     "mae": MAE,
     "mocov2plus": MoCoV2Plus,
     "mocov3": MoCoV3,
@@ -71,6 +73,7 @@ __all__ = [
     "BaseMethod",
     "DeepClusterV2",
     "DINO",
+    "FroSSL",
     "MAE",
     "LinearModel",
     "MoCoV2Plus",

--- a/solo/methods/frossl.py
+++ b/solo/methods/frossl.py
@@ -1,0 +1,156 @@
+# Copyright 2023 solo-learn development team.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies
+# or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+from typing import Any, Dict, List, Sequence
+
+import omegaconf
+import torch
+import torch.nn as nn
+from solo.losses.frossl import frossl_loss_func
+from solo.methods.base import BaseMethod
+from solo.utils.misc import omegaconf_select
+
+
+class FroSSL(BaseMethod):
+    def __init__(self, cfg: omegaconf.DictConfig):
+        """Implements FroSSL (https://arxiv.org/abs/2310.02903)
+
+        Extra cfg settings:
+            method_kwargs:
+                proj_hidden_dim (int): number of neurons of the hidden layers of the projector.
+                proj_output_dim (int): number of dimensions of the projected features.
+                invariance_weight (float): weight of the invariance term.
+        """
+
+        super().__init__(cfg)
+
+        self.invariance_weight: float = cfg.method_kwargs.invariance_weight
+
+        proj_hidden_dim: int = cfg.method_kwargs.proj_hidden_dim
+        proj_output_dim: int = cfg.method_kwargs.proj_output_dim
+
+        # projector
+        self.projector = nn.Sequential(
+            nn.Linear(self.features_dim, proj_hidden_dim),
+            nn.BatchNorm1d(proj_hidden_dim),
+            nn.ReLU(),
+            nn.Linear(proj_hidden_dim, proj_hidden_dim),
+            nn.BatchNorm1d(proj_hidden_dim),
+            nn.ReLU(),
+            nn.Linear(proj_hidden_dim, proj_output_dim),
+        )
+
+    @staticmethod
+    def add_and_assert_specific_cfg(cfg: omegaconf.DictConfig) -> omegaconf.DictConfig:
+        """Adds method specific default values/checks for config.
+
+        Args:
+            cfg (omegaconf.DictConfig): DictConfig object.
+
+        Returns:
+            omegaconf.DictConfig: same as the argument, used to avoid errors.
+        """
+
+        cfg = super(FroSSL, FroSSL).add_and_assert_specific_cfg(cfg)
+
+        assert not omegaconf.OmegaConf.is_missing(cfg, "method_kwargs.proj_hidden_dim")
+        assert not omegaconf.OmegaConf.is_missing(cfg, "method_kwargs.proj_output_dim")
+
+        cfg.method_kwargs.invariance_weight = omegaconf_select(
+            cfg,
+            "method_kwargs.invariance_weight",
+            1.0,
+        )
+
+        return cfg
+
+    @property
+    def learnable_params(self) -> List[dict]:
+        """Adds projector parameters to the parent's learnable parameters.
+
+        Returns:
+            List[dict]: list of learnable parameters.
+        """
+
+        extra_learnable_params = [{"name": "projector", "params": self.projector.parameters()}]
+        return super().learnable_params + extra_learnable_params
+
+    def forward(self, X: torch.Tensor) -> Dict[str, Any]:
+        """Performs the forward pass of the backbone and the projector.
+
+        Args:
+            X (torch.Tensor): a batch of images in the tensor format.
+
+        Returns:
+            Dict[str, Any]: a dict containing the outputs of the parent and the projected features.
+        """
+
+        out = super().forward(X)
+        z = self.projector(out["feats"])
+        out.update({"z": z})
+        return out
+
+    def multicrop_forward(self, X: torch.tensor) -> Dict[str, Any]:
+        """Performs the forward pass for the multicrop views.
+
+        Args:
+            X (torch.Tensor): batch of images in tensor format.
+
+        Returns:
+            Dict[]: a dict containing the outputs of the parent
+                and the projected features.
+        """
+
+        out = super().multicrop_forward(X)
+        z = self.projector(out["feats"])
+        out.update({"z": z})
+        return out
+
+    def training_step(self, batch: Sequence[Any], batch_idx: int) -> torch.Tensor:
+        """Training step for FroSSL reusing BaseMethod training step.
+
+        Args:
+            batch (Sequence[Any]): a batch of data in the format of [img_indexes, [X], Y], where
+                [X] is a list of size num_crops containing batches of images.
+            batch_idx (int): index of the batch.
+
+        Returns:
+            torch.Tensor: total loss composed of FroSSL loss and classification loss.
+        """
+
+        out = super().training_step(batch, batch_idx)
+        class_loss = out["loss"]
+        z = out["z"]
+
+        # ------- frossl loss -------
+        frossl_loss, invariance_term, regularization_term = frossl_loss_func(
+            z, invariance_weight=self.invariance_weight
+        )
+
+        self.log_dict(
+            {
+                "train_frossl_loss": frossl_loss,
+                "train_invariance_term": invariance_term,
+                "train_regularization_term": regularization_term,
+            },
+            on_epoch=True,
+            sync_dist=True,
+        )
+
+        return frossl_loss + class_loss

--- a/tests/losses/test_frossl.py
+++ b/tests/losses/test_frossl.py
@@ -1,0 +1,51 @@
+# Copyright 2023 solo-learn development team.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies
+# or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import torch
+from solo.losses import frossl_loss_func
+
+
+def test_frossl_loss():
+    b, f = 32, 128
+    z1 = torch.randn(b, f).requires_grad_()
+    z2 = torch.randn(b, f).requires_grad_()
+
+    loss, invariance, regularization = frossl_loss_func([z1, z2], invariance_weight=1.0)
+    initial_loss = loss.item()
+    assert loss != 0
+    # the loss returns its individual terms so the method can log them
+    assert isinstance(invariance, torch.Tensor)
+    assert isinstance(regularization, torch.Tensor)
+
+    for _ in range(20):
+        loss, _, _ = frossl_loss_func([z1, z2], invariance_weight=1.0)
+        loss.backward()
+        z1.data.add_(-0.5 * z1.grad)
+        z2.data.add_(-0.5 * z2.grad)
+
+        z1.grad = z2.grad = None
+
+    assert loss < initial_loss
+
+    # the loss should also support more than two views
+    z1 = torch.randn(b, f).requires_grad_()
+    z2 = torch.randn(b, f).requires_grad_()
+    z3 = torch.randn(b, f).requires_grad_()
+    loss, _, _ = frossl_loss_func([z1, z2, z3], invariance_weight=1.0)
+    assert loss != 0

--- a/tests/methods/test_frossl.py
+++ b/tests/methods/test_frossl.py
@@ -1,0 +1,88 @@
+# Copyright 2023 solo-learn development team.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies
+# or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import torch
+from solo.methods import FroSSL
+
+from .utils import gen_base_cfg, gen_batch, gen_trainer, prepare_dummy_dataloaders
+
+
+def test_frossl():
+    method_kwargs = {
+        "proj_hidden_dim": 2048,
+        "proj_output_dim": 2048,
+        "invariance_weight": 1.0,
+    }
+
+    cfg = gen_base_cfg("frossl", batch_size=2, num_classes=100, momentum=True)
+    cfg.method_kwargs = method_kwargs
+    model = FroSSL(cfg)
+
+    # test arguments
+    model.add_and_assert_specific_cfg(cfg)
+
+    # test parameters
+    assert model.learnable_params is not None
+
+    # test forward
+    batch, _ = gen_batch(cfg.optimizer.batch_size, cfg.data.num_classes, "imagenet100")
+    out = model(batch[1][0])
+    assert (
+        "logits" in out
+        and isinstance(out["logits"], torch.Tensor)
+        and out["logits"].size() == (cfg.optimizer.batch_size, cfg.data.num_classes)
+    )
+    assert (
+        "feats" in out
+        and isinstance(out["feats"], torch.Tensor)
+        and out["feats"].size() == (cfg.optimizer.batch_size, model.features_dim)
+    )
+    assert (
+        "z" in out
+        and isinstance(out["z"], torch.Tensor)
+        and out["z"].size() == (cfg.optimizer.batch_size, method_kwargs["proj_output_dim"])
+    )
+
+    # imagenet
+    model = FroSSL(cfg)
+
+    trainer = gen_trainer(cfg)
+    train_dl, val_dl = prepare_dummy_dataloaders(
+        "imagenet100",
+        num_large_crops=cfg.data.num_large_crops,
+        num_small_crops=0,
+        num_classes=cfg.data.num_classes,
+        batch_size=cfg.optimizer.batch_size,
+    )
+    trainer.fit(model, train_dl, val_dl)
+
+    # cifar
+    cfg.data.dataset = "cifar10"
+    cfg.data.num_classes = 10
+    model = FroSSL(cfg)
+
+    trainer = gen_trainer(cfg)
+    train_dl, val_dl = prepare_dummy_dataloaders(
+        "cifar10",
+        num_large_crops=cfg.data.num_large_crops,
+        num_small_crops=0,
+        num_classes=cfg.data.num_classes,
+        batch_size=cfg.optimizer.batch_size,
+    )
+    trainer.fit(model, train_dl, val_dl)


### PR DESCRIPTION
## Add FroSSL

This PR adds [FroSSL: Frobenius Norm Minimization for Efficient Multiview Self-Supervised Learning](https://arxiv.org/abs/2310.02903) (ECCV 2024) to solo-learn.

It supersedes the earlier unmerged PR #390 by @OFSkean (issue #389), and addresses the review feedback there.

### What's included
- `solo/methods/frossl.py` and `solo/losses/frossl.py`, following the conventions of the other methods.
- Registration in the `methods`/`losses` `__init__.py` files.
- Tests: `tests/methods/test_frossl.py`, `tests/losses/test_frossl.py`.
- Docs: `docs/source/solo/{methods,losses}/frossl.rst` + `index.rst` entries.
- Configs: `scripts/pretrain/{cifar,imagenet-100}/frossl.yaml`.
- README: method entry + CIFAR-10/100 results rows.

### Addressing the feedback from #390
- **Loss logging on the method side.** `frossl_loss_func` is now side-effect free and returns its individual terms `(loss, invariance, regularization)`; the method logs them in `training_step`, consistent with the other losses.
- **No new third-party dependency.** The original used `repitl` for an optional gaussian kernel; this implementation uses the paper's default linear kernel and drops that dependency.
- **Docs + README** are included.
- **Tests** are included (the previous PR had none).

### Reproduced results (ResNet18, 1000 epochs, online linear eval)
| Dataset | FroSSL (this PR) | Paper (Table 5) |
|---|---|---|
| CIFAR-10 | 92.10% | 92.8% |
| CIFAR-100 | 69.52% | 70.6% |

In line with the paper and with the existing VICReg/Barlow entries in the table. (solo-learn no longer hosts checkpoints as of 2026, so only results are reported, per the current Model Zoo policy.)

### Notes
- The loss always uses the multiview formulation (supports any number of views), which may differ negligibly from the paper's original 2-view function.

Based on the original implementation by @OFSkean.

### CI note
The failing `pre-commit.ci` check is a pre-existing issue unrelated to this PR — the repo's `jupytext` hook fails to build in the pre-commit.ci environment (it requires Node.js), and this check is also red on `main`. The GitHub Actions `lint` job runs the same hooks on a runner with Node.js and passes.
